### PR TITLE
add trait for simple AdminStyle development

### DIFF
--- a/AdminStyle.php
+++ b/AdminStyle.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace ProcessWire;
+
+trait AdminStyle
+{
+  public function loadStyle($style)
+  {
+    // do everything below only on admin pages
+    if ($this->wire->page->template != 'admin') return;
+
+    $config = $this->wire()->config;
+    $min = !$config->debug;
+
+    $compiled = $config->paths->assets . "admin";
+    if ($min) $compiled .= ".min.css";
+    else $compiled .= ".css";
+
+    $config->AdminThemeUikit = [
+      'style' => $style,
+      'compress' => $min,
+      'customCssFile' => $compiled,
+      'recompile' => @(filemtime($style) > filemtime($compiled)),
+      'vars' => $this->getStyleVars(),
+    ];
+  }
+
+  /**
+   * You can implement that method in your style module to define
+   * custom variables from PHP
+   */
+  public function getStyleVars(): array
+  {
+    return [];
+  }
+
+  /**
+   * Unlink admin.css to force recompile
+   */
+  public function resetAdminStyle()
+  {
+    $files = $this->wire->files;
+    $file = $this->wire->config->paths->assets . "admin";
+    if (is_file($file . ".css")) $files->unlink($file . ".css");
+    if (is_file($file . ".min.css")) $files->unlink($file . ".min.css");
+  }
+
+  public function ___install()
+  {
+    $this->resetAdminStyle();
+  }
+
+  public function ___uninstall()
+  {
+    $this->resetAdminStyle();
+  }
+}

--- a/Less.module.php
+++ b/Less.module.php
@@ -27,7 +27,7 @@ class Less extends WireData implements Module, ConfigurableModule {
 	public static function getModuleInfo() {
 		return array(
 			'title' => 'Less',
-			'version' => 3,
+			'version' => 4,
 			'summary' => 'Less CSS preprocessor for ProcessWire using Wikimedia Less.',
 			'author' => 'Bernhard Baumrock, Ryan Cramer',
 			'icon' => 'css3',


### PR DESCRIPTION
Hey @ryancramerdesign this update allows for super simple AdminStyle development as a module.

This has the benefit that users can create new AdminStyles very easily and also easily add all necessary assets to their styles. Also they can add Styles to the modules directory. Maybe we should add a new category "Admin Styles" for that?

I've also created a demo module to showcase how simple it is to create new AdminStyles: https://github.com/baumrock/AdminStyleHello